### PR TITLE
Fix streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+# v3
+
+Version 3 fixes the default behavior for input and output stream flags.
+These are now null by default, making absense distinguishable from the presence
+of a "-", and also avoiding the resumption of stdin unless expressly requested.
+
 # v2
 
 Be aware of the following changes when migrating from v1:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1369 @@
+{
+  "name": "shon",
+  "version": "3.0.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "http://archive.local.uber.internal/npm/camelcase/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+    },
+    "faucet": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/faucet/-/faucet-0.0.1.tgz",
+      "integrity": "sha1-WX3PHSGJosBiMhtZHo8VHtIDnZw=",
+      "dev": true,
+      "requires": {
+        "defined": "0.0.0",
+        "duplexer": "0.1.1",
+        "minimist": "0.0.5",
+        "sprintf": "0.1.5",
+        "tap-parser": "0.4.3",
+        "tape": "2.3.3",
+        "through2": "0.2.3"
+      },
+      "dependencies": {
+        "defined": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+          "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+          "dev": true
+        },
+        "duplexer": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+          "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY=",
+          "dev": true
+        },
+        "sprintf": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
+          "integrity": "sha1-j4PjmpMXwaUCy324BQ5Rxnn27c8=",
+          "dev": true
+        },
+        "tap-parser": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-0.4.3.tgz",
+          "integrity": "sha1-pOrhkMENdsehEZIf84u+TVjwnuo=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1",
+            "readable-stream": "1.1.13"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "1.0.1",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                  "dev": true
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "tape": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.3.tgz",
+          "integrity": "sha1-Lnzgox3wn41oUWZKcYQuDKUFevc=",
+          "dev": true,
+          "requires": {
+            "deep-equal": "0.1.2",
+            "defined": "0.0.0",
+            "inherits": "2.0.1",
+            "jsonify": "0.0.0",
+            "resumer": "0.0.0",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "deep-equal": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
+              "integrity": "sha1-skbCuApXCkfBG+HZvRBw7IeLh84=",
+              "dev": true
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+              "dev": true
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+              "dev": true
+            },
+            "resumer": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+              "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+              "dev": true,
+              "requires": {
+                "through": "2.3.8"
+              }
+            },
+            "through": {
+              "version": "2.3.8",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+              "dev": true
+            }
+          }
+        },
+        "through2": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+          "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.1.13",
+            "xtend": "2.1.2"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "1.0.1",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                  "dev": true
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "dev": true
+                }
+              }
+            },
+            "xtend": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+              "dev": true,
+              "requires": {
+                "object-keys": "0.4.0"
+              },
+              "dependencies": {
+                "object-keys": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                  "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "istanbul": {
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.21.tgz",
+      "integrity": "sha1-/Vw8dT2O2qamk+fHDNLMzjyxN+M=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.7",
+        "async": "1.4.2",
+        "escodegen": "1.6.1",
+        "esprima": "2.5.0",
+        "fileset": "0.2.1",
+        "handlebars": "4.0.3",
+        "js-yaml": "3.4.2",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.4",
+        "once": "1.3.2",
+        "resolve": "1.1.6",
+        "supports-color": "3.1.1",
+        "which": "1.1.2",
+        "wordwrap": "1.0.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+          "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+          "dev": true
+        },
+        "async": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+          "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
+          "dev": true
+        },
+        "escodegen": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+          "integrity": "sha1-Nn3hfYUQVA0SvG3Liz+Rg5EmWBU=",
+          "dev": true,
+          "requires": {
+            "esprima": "1.2.5",
+            "estraverse": "1.9.3",
+            "esutils": "1.1.6",
+            "optionator": "0.5.0",
+            "source-map": "0.1.43"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+              "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
+              "dev": true
+            },
+            "estraverse": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+              "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+              "dev": true
+            },
+            "esutils": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+              "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+              "dev": true
+            },
+            "optionator": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+              "dev": true,
+              "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "1.0.7",
+                "levn": "0.2.5",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.1",
+                "wordwrap": "0.0.3"
+              },
+              "dependencies": {
+                "deep-is": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+                  "dev": true
+                },
+                "fast-levenshtein": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+                  "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+                  "dev": true
+                },
+                "levn": {
+                  "version": "0.2.5",
+                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                  "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+                  "dev": true,
+                  "requires": {
+                    "prelude-ls": "1.1.2",
+                    "type-check": "0.3.1"
+                  }
+                },
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                  "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+                  "dev": true
+                },
+                "type-check": {
+                  "version": "0.3.1",
+                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                  "integrity": "sha1-kjOSPE2hdNCsVIDs/W74TDSetY0=",
+                  "dev": true,
+                  "requires": {
+                    "prelude-ls": "1.1.2"
+                  }
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                  "dev": true
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "amdefine": "1.0.0"
+              },
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            }
+          }
+        },
+        "esprima": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz",
+          "integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw=",
+          "dev": true
+        },
+        "fileset": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
+          "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
+          "dev": true,
+          "requires": {
+            "glob": "5.0.15",
+            "minimatch": "2.0.10"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
+              "requires": {
+                "inflight": "1.0.4",
+                "inherits": "2.0.1",
+                "minimatch": "2.0.10",
+                "once": "1.3.2",
+                "path-is-absolute": "1.0.0"
+              },
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                  "dev": true,
+                  "requires": {
+                    "once": "1.3.2",
+                    "wrappy": "1.0.1"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+                      "dev": true
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "dev": true
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.1"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "integrity": "sha1-2l+3iu9MRMnkrPUlBk+zII66sEU=",
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "0.2.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "integrity": "sha1-OPZzDAOqttXtu1K9k0iF51bXFnQ=",
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "handlebars": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.3.tgz",
+          "integrity": "sha1-N3aZHFWxcDstrpv1QPy6dZXRTfo=",
+          "dev": true,
+          "requires": {
+            "async": "1.4.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.4.24"
+          },
+          "dependencies": {
+            "optimist": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                  "dev": true
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                  "dev": true
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.0"
+              },
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                  "dev": true
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.4.24",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+              "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "async": "0.2.10",
+                "source-map": "0.1.34",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.5.4"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                  "dev": true,
+                  "optional": true
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                  "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "amdefine": "1.0.0"
+                  },
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+                  "dev": true,
+                  "optional": true
+                },
+                "yargs": {
+                  "version": "3.5.4",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "decamelize": "1.0.0",
+                    "window-size": "0.1.0",
+                    "wordwrap": "0.0.2"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                      "integrity": "sha1-UocSL3FpHUUFsY/yJY3EAKWyOEc=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.2.tgz",
+          "integrity": "sha1-EJQjg+5LnCwg7eI4jBsPOHiisM4=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.2",
+            "esprima": "2.2.0"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+              "integrity": "sha1-vPrjkFllbRlz0LnmoadBVLWpoTY=",
+              "dev": true,
+              "requires": {
+                "lodash": "3.10.1",
+                "sprintf-js": "1.0.3"
+              },
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                  "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+                  "dev": true
+                },
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                  "dev": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+              "integrity": "sha1-QpLB1o5Bc9gV+iKQ3Hr8ltgfzYM=",
+              "dev": true
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+          "integrity": "sha1-3WO8nHKm5Ohbhc3AyjFFmPrO3l4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.7"
+          }
+        },
+        "once": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+          "integrity": "sha1-2P7sqTsDnsHc3ud0HJK9rF4oCBs=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.1"
+          },
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+              "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+              "dev": true
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+          "integrity": "sha1-00kq0FTKgA9b76YS5hvqwe7Jj48=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.1.tgz",
+          "integrity": "sha1-ELcw6iw26fN5CgNfcbAHJZJg7Es=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+              "dev": true
+            }
+          }
+        },
+        "which": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.1.2.tgz",
+          "integrity": "sha1-SGxIr23+zHp9z5xlWs8QjS3L3z0=",
+          "dev": true,
+          "requires": {
+            "is-absolute": "0.1.7"
+          },
+          "dependencies": {
+            "is-absolute": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+              "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+              "dev": true,
+              "requires": {
+                "is-relative": "0.1.3"
+              },
+              "dependencies": {
+                "is-relative": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                  "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
+      }
+    },
+    "opn-cli": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/opn-cli/-/opn-cli-1.0.0.tgz",
+      "integrity": "sha1-bgrqFLmr24g/6c8ECWZoygssa1k=",
+      "dev": true,
+      "requires": {
+        "meow": "3.4.1",
+        "opn": "3.0.2"
+      },
+      "dependencies": {
+        "meow": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.4.1.tgz",
+          "integrity": "sha1-770zGCApdlku/HwP7vsuN/15POo=",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "1.0.0",
+            "loud-rejection": "1.0.0",
+            "minimist": "1.2.0",
+            "object-assign": "4.0.1",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
+          },
+          "dependencies": {
+            "camelcase-keys": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+              "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
+              "dev": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "map-obj": "1.0.1"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                  "dev": true
+                },
+                "map-obj": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                  "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+                  "dev": true
+                }
+              }
+            },
+            "loud-rejection": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz",
+              "integrity": "sha1-19oHN36+jHacmp3/QrImsIXoMkY=",
+              "dev": true
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
+            },
+            "object-assign": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+              "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0=",
+              "dev": true
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "dev": true,
+              "requires": {
+                "find-up": "1.0.0",
+                "read-pkg": "1.1.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
+                  "integrity": "sha1-3wpUq+69+ZhBaPpVa9GKjyS00Vw=",
+                  "dev": true,
+                  "requires": {
+                    "path-exists": "2.0.0",
+                    "pinkie-promise": "1.0.0"
+                  },
+                  "dependencies": {
+                    "path-exists": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
+                      "integrity": "sha1-xO/jfX/ceS+aApznkG4JXhafm+E=",
+                      "dev": true,
+                      "requires": {
+                        "pinkie-promise": "1.0.0"
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                      "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+                      "dev": true,
+                      "requires": {
+                        "pinkie": "1.0.0"
+                      },
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "read-pkg": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                  "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                  "dev": true,
+                  "requires": {
+                    "load-json-file": "1.0.1",
+                    "normalize-package-data": "2.3.4",
+                    "path-type": "1.0.0"
+                  },
+                  "dependencies": {
+                    "load-json-file": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
+                      "integrity": "sha1-0k4Uvif2imrsD4I2WyPhAUYD/Bk=",
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.2",
+                        "parse-json": "2.2.0",
+                        "pify": "2.2.0",
+                        "pinkie-promise": "1.0.0",
+                        "strip-bom": "2.0.0"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.2",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                          "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc=",
+                          "dev": true
+                        },
+                        "parse-json": {
+                          "version": "2.2.0",
+                          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                          "dev": true,
+                          "requires": {
+                            "error-ex": "1.2.0"
+                          },
+                          "dependencies": {
+                            "error-ex": {
+                              "version": "1.2.0",
+                              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.2.0.tgz",
+                              "integrity": "sha1-ldUYO+YEejKpdVY5Zi0rc3sip2o=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "pify": {
+                          "version": "2.2.0",
+                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz",
+                          "integrity": "sha1-xl6HAkbHi1pM5sCm81BIya7NbP8=",
+                          "dev": true
+                        },
+                        "pinkie-promise": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+                          "dev": true,
+                          "requires": {
+                            "pinkie": "1.0.0"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                              "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "strip-bom": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                          "dev": true,
+                          "requires": {
+                            "is-utf8": "0.2.0"
+                          },
+                          "dependencies": {
+                            "is-utf8": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                              "integrity": "sha1-uKpUElrmJr/k4765ZfFqicWKETc=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "normalize-package-data": {
+                      "version": "2.3.4",
+                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.4.tgz",
+                      "integrity": "sha1-uSIzzm7wT71rwMBd6tFVrzOmI+A=",
+                      "dev": true,
+                      "requires": {
+                        "hosted-git-info": "2.1.4",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.0.3",
+                        "validate-npm-package-license": "3.0.1"
+                      },
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.1.4",
+                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+                          "integrity": "sha1-2elTsmmIvogJbEbpJklNlgTDAPg=",
+                          "dev": true
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                          "dev": true,
+                          "requires": {
+                            "builtin-modules": "1.1.0"
+                          },
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.0",
+                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+                              "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "5.0.3",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+                          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+                          "dev": true
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                          "dev": true,
+                          "requires": {
+                            "spdx-correct": "1.0.1",
+                            "spdx-expression-parse": "1.0.0"
+                          },
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.1.tgz",
+                              "integrity": "sha1-rAdfXy9qBsC/3RyEfrPd492CIeo=",
+                              "dev": true,
+                              "requires": {
+                                "spdx-license-ids": "1.0.2"
+                              },
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz",
+                                  "integrity": "sha1-BnTpyaIw+YABa1sHOhCqFlcBZ3w=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
+                              "integrity": "sha1-T7t+c4yemPoLCRTf2WGsZin7ze8=",
+                              "dev": true,
+                              "requires": {
+                                "spdx-exceptions": "1.0.3",
+                                "spdx-license-ids": "1.0.2"
+                              },
+                              "dependencies": {
+                                "spdx-exceptions": {
+                                  "version": "1.0.3",
+                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz",
+                                  "integrity": "sha1-Oexe0s693wjRgFVdfpnDr/m0dko=",
+                                  "dev": true
+                                },
+                                "spdx-license-ids": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.2.tgz",
+                                  "integrity": "sha1-BnTpyaIw+YABa1sHOhCqFlcBZ3w=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "path-type": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
+                      "integrity": "sha1-UbEn1IhBAPWAglbkXUcXFroW9i0=",
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.2",
+                        "pify": "2.2.0",
+                        "pinkie-promise": "1.0.0"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.2",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                          "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc=",
+                          "dev": true
+                        },
+                        "pify": {
+                          "version": "2.2.0",
+                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz",
+                          "integrity": "sha1-xl6HAkbHi1pM5sCm81BIya7NbP8=",
+                          "dev": true
+                        },
+                        "pinkie-promise": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+                          "dev": true,
+                          "requires": {
+                            "pinkie": "1.0.0"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                              "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "redent": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+              "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+              "dev": true,
+              "requires": {
+                "indent-string": "2.1.0",
+                "strip-indent": "1.0.1"
+              },
+              "dependencies": {
+                "indent-string": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                  "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                  "dev": true,
+                  "requires": {
+                    "repeating": "2.0.0"
+                  },
+                  "dependencies": {
+                    "repeating": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                      "integrity": "sha1-/SfW0mTRj76/qlZVPde4JTWlA04=",
+                      "dev": true,
+                      "requires": {
+                        "is-finite": "1.0.1"
+                      },
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                          "dev": true,
+                          "requires": {
+                            "number-is-nan": "1.0.0"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "strip-indent": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                  "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+                  "dev": true,
+                  "requires": {
+                    "get-stdin": "4.0.1"
+                  },
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "trim-newlines": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+              "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+              "dev": true
+            }
+          }
+        },
+        "opn": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.2.tgz",
+          "integrity": "sha1-0zgGBwCLLlzEHnvVJPVMatve6ng=",
+          "dev": true,
+          "requires": {
+            "object-assign": "3.0.0"
+          },
+          "dependencies": {
+            "object-assign": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "pegjs": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.9.0.tgz",
+      "integrity": "sha1-9q76LjzlYWkgjlIXnf5B+JFBo2k=",
+      "dev": true
+    },
+    "rezult": {
+      "version": "1.1.0",
+      "resolved": "http://archive.local.uber.internal/npm/rezult/rezult-1.1.0.tgz",
+      "integrity": "sha1-Jymr+VQoe8+6feobp5qU+/8h+2s="
+    },
+    "tape": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.2.0.tgz",
+      "integrity": "sha1-rlBEidU6n50S2TVAZJ3zcepfh40=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "0.0.0",
+        "function-bind": "1.0.2",
+        "glob": "5.0.15",
+        "has": "1.0.1",
+        "inherits": "2.0.1",
+        "object-inspect": "1.0.2",
+        "resumer": "0.0.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+          "dev": true
+        },
+        "defined": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+          "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+          "dev": true
+        },
+        "function-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.0.2.tgz",
+          "integrity": "sha1-woc7acXm18765H0lVRcpJsjC4F4=",
+          "dev": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.4",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.0",
+            "once": "1.3.2",
+            "path-is-absolute": "1.0.0"
+          },
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+              "dev": true,
+              "requires": {
+                "once": "1.3.2",
+                "wrappy": "1.0.1"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+                  "dev": true
+                }
+              }
+            },
+            "minimatch": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.1"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "integrity": "sha1-2l+3iu9MRMnkrPUlBk+zII66sEU=",
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "0.2.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "integrity": "sha1-OPZzDAOqttXtu1K9k0iF51bXFnQ=",
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "integrity": "sha1-2P7sqTsDnsHc3ud0HJK9rF4oCBs=",
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.1"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+                  "dev": true
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+              "dev": true
+            }
+          }
+        },
+        "has": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+          "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+          "dev": true,
+          "requires": {
+            "function-bind": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        },
+        "object-inspect": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.0.2.tgz",
+          "integrity": "sha1-qXiFtVPldetACevAm92psc0hl5o=",
+          "dev": true
+        },
+        "resumer": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+          "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+          "dev": true,
+          "requires": {
+            "through": "2.3.8"
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+          "dev": true
+        }
+      }
+    }
+  }
+}

--- a/test/delegate.js
+++ b/test/delegate.js
@@ -30,7 +30,7 @@ Delegate.prototype.isDone = function isDone() {
 
 Delegate.prototype.error = function error(message) {
     var key = 'error' + this.index++;
-    this.assert.equals(message, this.expected[key], 'Logs ' + key + ': ' + message);
+    this.assert.ok(message.lastIndexOf(this.expected[key], 0) == 0, 'Logs ' + key + ': ' + message);
     delete this.expected[key];
     this.exitCode = 1;
 };

--- a/types.js
+++ b/types.js
@@ -10,11 +10,7 @@ var ValueCollector = require('./value-collector');
 // TODO SetCollector
 
 var types = {
-    defaults: {
-        input: defaultInput,
-        atinput: defaultInput,
-        output: defaultOutput
-    },
+    defaults: {},
     parsers: {
         shon: ShonParser,
         jshon: JshonParser,
@@ -72,16 +68,12 @@ function InputConverter(args) {
 
 InputConverter.prototype.convert = function convert(value) {
     if (value === '-') {
-        return defaultInput();
+        process.stdin.resume();
+        return process.stdin;
     } else {
         return fs.createReadStream(value, this.encoding);
     }
 };
-
-function defaultInput() {
-    process.stdin.resume();
-    return process.stdin;
-}
 
 function OutputConverter(args) {
     this.encoding = args.encoding || 'utf8';
@@ -89,16 +81,11 @@ function OutputConverter(args) {
 
 OutputConverter.prototype.convert = function convert(value) {
     if (value === '-') {
-        process.stdin.resume();
         return process.stdout;
     } else {
         return fs.createWriteStream(value, this.encoding);
     }
 };
-
-function defaultOutput() {
-    return process.stdout;
-}
 
 function AtInputConverter(args) {
     this.encoding = args.encoding || 'utf8';


### PR DESCRIPTION
With a brief detour to relax tests so they’ll pass with newer versions of v8’s JSON parser, which has made its error messages less perplexing, and to account for new versions of npm, this change fixes the behavior of input and output stream flags, which previously defaulted to stdio and would resume stdin even if the flag is absent.

Unfortunately, I can’t be sure that this "fix" won’t break existing usage, so this will have to be a major bump. Given that this isn’t heavily used, I’m fine with making the jump.